### PR TITLE
Broker interceptor

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -6,7 +6,7 @@ package turnpike
 // Authorize takes the session and the message (request), and returns true if
 // the request is authorized, otherwise false.
 type Authorizer interface {
-	Authorize(session Session, msg Message) (bool, error)
+	Authorize(session *Session, msg Message) (bool, error)
 }
 
 // DefaultAuthorizer always returns authorized.
@@ -18,6 +18,6 @@ func NewDefaultAuthorizer() Authorizer {
 	return &defaultAuthorizer{}
 }
 
-func (da *defaultAuthorizer) Authorize(session Session, msg Message) (bool, error) {
+func (da *defaultAuthorizer) Authorize(session *Session, msg Message) (bool, error) {
 	return true, nil
 }

--- a/broker_distributor.go
+++ b/broker_distributor.go
@@ -1,18 +1,18 @@
 package turnpike
 
-// BrokerInterceptor is the interface that intercepts broker events
-type BrokerInterceptor interface {
+// BrokerDistributor is the interface that intercepts broker events
+type BrokerDistributor interface {
 	ShouldPublish(pub, sub *Session, options map[string]interface{}, msg *Publish) bool
 }
 
-type defaultBrokerInterceptor struct{}
+type defaultBrokerDistributor struct{}
 
 // NewDefaultBrokerInterceptor returns a simple broker interceptor
-func NewDefaultBrokerInterceptor() *defaultBrokerInterceptor {
-	return &defaultBrokerInterceptor{}
+func NewDefaultBrokerDistributor() *defaultBrokerDistributor {
+	return &defaultBrokerDistributor{}
 }
 
-func (bi *defaultBrokerInterceptor) ShouldPublish(pub, sub *Session, options map[string]interface{}, msg *Publish) bool {
+func (bi *defaultBrokerDistributor) ShouldPublish(pub, sub *Session, options map[string]interface{}, msg *Publish) bool {
 	// don't send event to publisher
 	if sub == pub {
 		return false

--- a/broker_interceptor.go
+++ b/broker_interceptor.go
@@ -1,0 +1,28 @@
+package turnpike
+
+// BrokerInterceptor is the interface that intercepts broker events
+type BrokerInterceptor interface {
+	ShouldPublish(pub, sub *Session, options map[string]interface{}, msg *Publish) bool
+}
+
+type defaultBrokerInterceptor struct{}
+
+// NewDefaultBrokerInterceptor returns a simple broker interceptor
+func NewDefaultBrokerInterceptor() *defaultBrokerInterceptor {
+	return &defaultBrokerInterceptor{}
+}
+
+func (bi *defaultBrokerInterceptor) ShouldPublish(pub, sub *Session, options map[string]interface{}, msg *Publish) bool {
+	// don't send event to publisher
+	if sub == pub {
+		return false
+	}
+
+	for option, pubValue := range msg.Options {
+		if subValue, ok := options[option]; ok && subValue != pubValue {
+			return false
+		}
+	}
+
+	return true
+}

--- a/broker_test.go
+++ b/broker_test.go
@@ -22,7 +22,7 @@ func (s *TestPeer) Close() error            { return nil }
 
 func TestSubscribe(t *testing.T) {
 	Convey("Subscribing to a topic", t, func() {
-		broker := NewDefaultBroker().(*defaultBroker)
+		broker := NewDefaultBroker()
 		subscriber := &TestPeer{}
 		sess := &Session{Peer: subscriber}
 		testTopic := URI("turnpike.test.topic")
@@ -50,7 +50,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	broker := NewDefaultBroker().(*defaultBroker)
+	broker := NewDefaultBroker()
 	subscriber := &TestPeer{}
 	testTopic := URI("turnpike.test.topic")
 	msg := &Subscribe{Request: 123, Topic: testTopic}
@@ -79,7 +79,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	broker := NewDefaultBroker().(*defaultBroker)
+	broker := NewDefaultBroker()
 	subscriber := &TestPeer{}
 	sess := &Session{Peer: subscriber}
 	testTopic := URI("turnpike.test.topic")

--- a/broker_test.go
+++ b/broker_test.go
@@ -41,8 +41,6 @@ func TestSubscribe(t *testing.T) {
 			So(topic, ShouldEqual, testTopic)
 			_, ok = broker.routes[testTopic]
 			So(ok, ShouldBeTrue)
-			_, ok = broker.options[testTopic]
-			So(ok, ShouldBeTrue)
 			_, ok = broker.sessions[sess]
 			So(ok, ShouldBeTrue)
 		})
@@ -74,8 +72,6 @@ func TestUnsubscribe(t *testing.T) {
 			So(ok, ShouldBeFalse)
 			_, ok = broker.routes[testTopic]
 			So(ok, ShouldBeFalse)
-			_, ok = broker.options[testTopic]
-			So(ok, ShouldBeFalse)
 			_, ok = broker.sessions[sess]
 			So(ok, ShouldBeFalse)
 		})
@@ -104,14 +100,10 @@ func TestRemove(t *testing.T) {
 			So(ok, ShouldBeFalse)
 			_, ok = broker.routes[testTopic]
 			So(ok, ShouldBeFalse)
-			_, ok = broker.options[testTopic]
-			So(ok, ShouldBeFalse)
 
 			_, ok = broker.subscriptions[sub2]
 			So(ok, ShouldBeFalse)
 			_, ok = broker.routes[testTopic2]
-			So(ok, ShouldBeFalse)
-			_, ok = broker.options[testTopic2]
 			So(ok, ShouldBeFalse)
 
 			_, ok = broker.sessions[sess]

--- a/dealer.go
+++ b/dealer.go
@@ -5,21 +5,21 @@ import "sync"
 // A Dealer routes and manages RPC calls to callees.
 type Dealer interface {
 	// Register a procedure on an endpoint
-	Register(Sender, *Register)
+	Register(*Session, *Register)
 	// Unregister a procedure on an endpoint
-	Unregister(Sender, *Unregister)
+	Unregister(*Session, *Unregister)
 	// Call a procedure on an endpoint
-	Call(Sender, *Call)
+	Call(*Session, *Call)
 	// Return the result of a procedure call
-	Yield(Sender, *Yield)
+	Yield(*Session, *Yield)
 	// Handle an ERROR message from an invocation
-	Error(Sender, *Error)
+	Error(*Session, *Error)
 	// Remove a callee's registrations
-	RemovePeer(Sender)
+	RemovePeer(*Session)
 }
 
 type remoteProcedure struct {
-	Endpoint  Sender
+	Endpoint  *Session
 	Procedure URI
 }
 
@@ -31,11 +31,11 @@ type defaultDealer struct {
 	// multiple callees for the same procedure
 	registrations map[URI]ID
 	// keep track of call IDs so we can send the response to the caller
-	calls map[ID]Sender
+	calls map[ID]*Session
 	// link the invocation ID to the call ID
 	invocations map[ID]ID
 	// keep track of callee's registrations
-	callees map[Sender]map[ID]bool
+	callees map[*Session]map[ID]bool
 	// protect maps from concurrent access
 	lock sync.Mutex
 }
@@ -45,13 +45,13 @@ func NewDefaultDealer() Dealer {
 	return &defaultDealer{
 		procedures:    make(map[ID]remoteProcedure),
 		registrations: make(map[URI]ID),
-		calls:         make(map[ID]Sender),
+		calls:         make(map[ID]*Session),
 		invocations:   make(map[ID]ID),
-		callees:       make(map[Sender]map[ID]bool),
+		callees:       make(map[*Session]map[ID]bool),
 	}
 }
 
-func (d *defaultDealer) Register(callee Sender, msg *Register) {
+func (d *defaultDealer) Register(callee *Session, msg *Register) {
 	reg := NewID()
 	d.lock.Lock()
 	if id, ok := d.registrations[msg.Procedure]; ok {
@@ -77,7 +77,7 @@ func (d *defaultDealer) Register(callee Sender, msg *Register) {
 	})
 }
 
-func (d *defaultDealer) Unregister(callee Sender, msg *Unregister) {
+func (d *defaultDealer) Unregister(callee *Session, msg *Unregister) {
 	d.lock.Lock()
 	if procedure, ok := d.procedures[msg.Registration]; !ok {
 		d.lock.Unlock()
@@ -101,7 +101,7 @@ func (d *defaultDealer) Unregister(callee Sender, msg *Unregister) {
 	}
 }
 
-func (d *defaultDealer) Call(caller Sender, msg *Call) {
+func (d *defaultDealer) Call(caller *Session, msg *Call) {
 	d.lock.Lock()
 	if reg, ok := d.registrations[msg.Procedure]; !ok {
 		d.lock.Unlock()
@@ -143,7 +143,7 @@ func (d *defaultDealer) Call(caller Sender, msg *Call) {
 	}
 }
 
-func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
+func (d *defaultDealer) Yield(callee *Session, msg *Yield) {
 	d.lock.Lock()
 	if callID, ok := d.invocations[msg.Request]; !ok {
 		d.lock.Unlock()
@@ -171,7 +171,7 @@ func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
 	}
 }
 
-func (d *defaultDealer) Error(peer Sender, msg *Error) {
+func (d *defaultDealer) Error(peer *Session, msg *Error) {
 	d.lock.Lock()
 	if callID, ok := d.invocations[msg.Request]; !ok {
 		d.lock.Unlock()
@@ -197,7 +197,7 @@ func (d *defaultDealer) Error(peer Sender, msg *Error) {
 	}
 }
 
-func (d *defaultDealer) RemovePeer(callee Sender) {
+func (d *defaultDealer) RemovePeer(callee *Session) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	for reg := range d.callees[callee] {
@@ -209,14 +209,14 @@ func (d *defaultDealer) RemovePeer(callee Sender) {
 	}
 }
 
-func (d *defaultDealer) addCalleeRegistration(callee Sender, reg ID) {
+func (d *defaultDealer) addCalleeRegistration(callee *Session, reg ID) {
 	if _, ok := d.callees[callee]; !ok {
 		d.callees[callee] = make(map[ID]bool)
 	}
 	d.callees[callee][reg] = true
 }
 
-func (d *defaultDealer) removeCalleeRegistration(callee Sender, reg ID) {
+func (d *defaultDealer) removeCalleeRegistration(callee *Session, reg ID) {
 	if _, ok := d.callees[callee]; !ok {
 		return
 	}

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -9,10 +9,11 @@ import (
 func TestRegister(t *testing.T) {
 	Convey("Registering a procedure", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
-		callee := &TestSender{}
+		callee := &TestPeer{}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
+		sess := &Session{Peer: callee}
+		dealer.Register(sess, msg)
 
 		Convey("The callee should have received a REGISTERED message", func() {
 			reg := callee.received.(*Registered).Registration
@@ -31,7 +32,7 @@ func TestRegister(t *testing.T) {
 
 		Convey("The same procedure cannot be registered more than once", func() {
 			msg := &Register{Request: 321, Procedure: testProcedure}
-			dealer.Register(callee, msg)
+			dealer.Register(sess, msg)
 			err := callee.received.(*Error)
 			So(err.Error, ShouldEqual, ErrProcedureAlreadyExists)
 			So(err.Details, ShouldNotBeNil)
@@ -41,15 +42,16 @@ func TestRegister(t *testing.T) {
 
 func TestUnregister(t *testing.T) {
 	dealer := NewDefaultDealer().(*defaultDealer)
-	callee := &TestSender{}
+	callee := &TestPeer{}
 	testProcedure := URI("turnpike.test.endpoint")
 	msg := &Register{Request: 123, Procedure: testProcedure}
-	dealer.Register(callee, msg)
+	sess := &Session{Peer: callee}
+	dealer.Register(sess, msg)
 	reg := callee.received.(*Registered).Registration
 
 	Convey("Unregistering a procedure", t, func() {
 		msg := &Unregister{Request: 124, Registration: reg}
-		dealer.Unregister(callee, msg)
+		dealer.Unregister(sess, msg)
 
 		Convey("The callee should have received an UNREGISTERED message", func() {
 			unreg := callee.received.(*Unregistered).Request
@@ -68,15 +70,17 @@ func TestUnregister(t *testing.T) {
 func TestCall(t *testing.T) {
 	Convey("With a procedure registered", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
-		callee := &TestSender{}
+		callee := &TestPeer{}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
-		caller := &TestSender{}
+		sess := &Session{Peer: callee}
+		dealer.Register(sess, msg)
+		caller := &TestPeer{}
+		callerSession := &Session{Peer: caller}
 
 		Convey("Calling an invalid procedure", func() {
 			msg := &Call{Request: 124, Procedure: URI("turnpike.test.bad")}
-			dealer.Call(caller, msg)
+			dealer.Call(callerSession, msg)
 
 			Convey("The caller should have received an ERROR message", func() {
 				err := caller.received.(*Error)
@@ -87,7 +91,7 @@ func TestCall(t *testing.T) {
 
 		Convey("Calling a valid procedure", func() {
 			msg := &Call{Request: 125, Procedure: testProcedure}
-			dealer.Call(caller, msg)
+			dealer.Call(callerSession, msg)
 
 			Convey("The callee should have received an INVOCATION message", func() {
 				So(callee.received.MessageType(), ShouldEqual, INVOCATION)
@@ -95,7 +99,7 @@ func TestCall(t *testing.T) {
 
 				Convey("And the callee responds with a YIELD message", func() {
 					msg := &Yield{Request: inv.Request}
-					dealer.Yield(callee, msg)
+					dealer.Yield(sess, msg)
 
 					Convey("The caller should have received a RESULT message", func() {
 						So(caller.received.MessageType(), ShouldEqual, RESULT)
@@ -105,7 +109,7 @@ func TestCall(t *testing.T) {
 
 				Convey("And the callee responds with an ERROR message", func() {
 					msg := &Error{Request: inv.Request}
-					dealer.Error(callee, msg)
+					dealer.Error(sess, msg)
 
 					Convey("The caller should have received an ERROR message", func() {
 						So(caller.received.MessageType(), ShouldEqual, ERROR)
@@ -120,24 +124,23 @@ func TestCall(t *testing.T) {
 func TestRemovePeer(t *testing.T) {
 	Convey("With a procedure registered", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
-		callee := &TestSender{}
+		callee := &TestPeer{}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
+		sess := &Session{Peer: callee}
+		dealer.Register(sess, msg)
 		reg := callee.received.(*Registered).Registration
 		So(dealer.registrations, ShouldContainKey, testProcedure)
 		So(dealer.procedures, ShouldContainKey, reg)
-		So(dealer.callees[callee], ShouldContainKey, reg)
 
 		Convey("Calling RemoveSession should remove the registration", func() {
-			dealer.RemovePeer(callee)
+			dealer.RemovePeer(sess)
 			So(dealer.registrations, ShouldNotContainKey, testProcedure)
 			So(dealer.procedures, ShouldNotContainKey, reg)
-			So(dealer.callees[callee], ShouldNotContainKey, reg)
 
 			Convey("And registering the endpoint again should succeed", func() {
 				msg.Request = 124
-				dealer.Register(callee, msg)
+				dealer.Register(sess, msg)
 				So(callee.received.MessageType(), ShouldEqual, REGISTERED)
 			})
 		})

--- a/interceptor.go
+++ b/interceptor.go
@@ -6,7 +6,7 @@ package turnpike
 // Intercept takes the session and (a pointer to) the message, and (possibly)
 // modifies the message.
 type Interceptor interface {
-	Intercept(session Session, msg *Message)
+	Intercept(session *Session, msg *Message)
 }
 
 // DefaultInterceptor does nothing :)
@@ -18,5 +18,5 @@ func NewDefaultInterceptor() Interceptor {
 	return &defaultInterceptor{}
 }
 
-func (di *defaultInterceptor) Intercept(session Session, msg *Message) {
+func (di *defaultInterceptor) Intercept(session *Session, msg *Message) {
 }


### PR DESCRIPTION
- Passing in `session` instead of `peer` into broker/dealer calls
- Cleaned up the defaultBroker maps
- introduced BrokerInterceptor

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/turnpike/5)

<!-- Reviewable:end -->
