### PR TITLE
Add logging for WAMP session establishment

### DIFF
--- a/log.go
+++ b/log.go
@@ -14,12 +14,14 @@ var (
 type Logger interface {
 	Println(v ...interface{})
 	Printf(format string, v ...interface{})
+	Output(calldepth int, s string) error
 }
 
 type noopLogger struct{}
 
 func (n noopLogger) Println(v ...interface{})               {}
 func (n noopLogger) Printf(format string, v ...interface{}) {}
+func (n noopLogger) Output(calldepth int, s string) error   { return nil }
 
 // setup logger for package, noop by default
 func init() {

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -100,7 +100,8 @@ func (s *WebsocketServer) GetLocalClient(realm string, details map[string]interf
 
 // ServeHTTP handles a new HTTP connection.
 func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Println("WebsocketServer.ServeHTTP", r.Method, r.RequestURI)
+	log.Output(1, fmt.Sprintf("WebsocketServer.ServeHTTP: begin %s", r.RemoteAddr))
+
 	// TODO: subprotocol?
 	conn, err := s.Upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -108,7 +109,9 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	log.Output(1, fmt.Sprintf("WebsocketServer.ServeHTTP: done Upgrade %s", r.RemoteAddr))
 	s.handleWebsocket(conn)
+	log.Output(1, fmt.Sprintf("WebsocketServer.ServeHTTP: end %s", r.RemoteAddr))
 }
 
 func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
@@ -147,5 +150,6 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 	go peer.runReadMessages()
 	go peer.runWriteMessages()
 
+	log.Output(1, fmt.Sprintf("WebsocketServer: accepting peer %s", conn.RemoteAddr()))
 	logErr(s.Router.Accept(&peer))
 }


### PR DESCRIPTION
Recently we have been seeing a marked increase in latency with `GET /api/worker/ws` requests that clients make to establish WAMP connection. Many are taking 3 to 5 seconds to complete. This PR adds extra logging to diagnose this.

The turnpike packages uses the GO logging API. But the existing usage of Print and Printf methods do not allow any selectivity in what gets logged. It is all or nothing, and will end up being too verbose on a production server, logging every WAMP message in great detail.

Hence this PR uses the `Output` method of the logging interface to gain selectivity in logging, focussing now on the `GET /api/worker/ws` processing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/turnpike/9)
<!-- Reviewable:end -->
